### PR TITLE
Clean up and improve networking code

### DIFF
--- a/Networking/MessageHeader.cs
+++ b/Networking/MessageHeader.cs
@@ -40,11 +40,12 @@ namespace Networking
 
         public byte [] toByteArray()
         {
-            var formatter = new BinaryFormatter();
-            MemoryStream stream = new MemoryStream();
-            formatter.Serialize(stream, this);
-            return stream.ToArray();
+            using (var stream = new MemoryStream())
+            {
+                var formatter = new BinaryFormatter();
+                formatter.Serialize(stream, this);
+                return stream.ToArray();
+            }
         }
-        
     }
 }

--- a/Networking/messageSender.cs
+++ b/Networking/messageSender.cs
@@ -11,25 +11,26 @@ namespace Networking
 {
     public class MessageSender
     {
-        public MessageSender(MessageBase message,Socket socket)
+        public MessageSender(MessageBase message, Socket socket)
         {
-            var formatter = new BinaryFormatter();
-            MemoryStream stream = new MemoryStream();
-            using (socket)
+            try
             {
-                try
+                using (var stream = new MemoryStream())
                 {
+                    var headerBuffer = message.header.toByteArray();
+                    stream.Write(headerBuffer, 0, headerBuffer.Length);
+
+                    var formatter = new BinaryFormatter();
                     formatter.Serialize(stream, message);
-                    socket.Send(message.header.toByteArray());
+
                     socket.Send(stream.ToArray());
                 }
-                catch(Exception e)
-                {
-                    Console.Write("Error sending message " + message.header.messageID);
-                    Console.WriteLine(e.Message);
-                }
             }
-                
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Unable to send message {message.header.messageID.ToString()}");
+                Console.WriteLine($"The following error occurred: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces the following changes:

* Use `using` blocks for `MemoryStream` so that the `MemoryStream` is closed as soon as the stream goes out of scope. 

   In general, classes that implement the `IDisposable` interface should be instantiated inside a `using` block so that its `IDisposable.Dispose()` method is called once the class goes out of scope. For more information, see [this blog post about `IDisposable` and `using` blocks](https://coding.abel.nu/2011/12/idisposable-and-using-in-c/).

* Change `MessageSender` so that it uses the `MemoryStream` it creates to write the message's header and then the message's payload data to the `MemoryStream`, take the resulting `byte[]` that is returned upon calling `MemoryStream.ToArray()`, and write it to the socket in one go (instead of sending it separately). 

   It probably would be better to send the entire message header and payload `byte[]` with a single `Socket.Send()` instead of splitting it up into two `Send()` calls (especially since the message header and payload should be together, if all possible).

* Use string interpolations for printing errors that can occur while sending the message with `MessageSender` instead of concatenating it.

    Mainly to improve readability of the code. 😛 